### PR TITLE
update fish_prompt caret for fish 3.1

### DIFF
--- a/fish/functions/fish_prompt.fish
+++ b/fish/functions/fish_prompt.fish
@@ -14,9 +14,9 @@ function fish_prompt
   echo -n ' '
 
   # the git shell
-  if git branch ^&- >&-
+  if git branch 2>&- >&-
     set_color green --background magenta
-    echo -n (git branch --no-color ^ /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ \1 /')
+    echo -n (git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ \1 /')
     set_color --background normal
   end
 


### PR DESCRIPTION
In Fish 3.x `^` is deprecated per the [docs](git@github.com:alanbsmith/dotfiles-1.git). This should fix it. 😄 